### PR TITLE
エラー時Vmon=0に設定

### DIFF
--- a/EH900_main.ino
+++ b/EH900_main.ino
@@ -172,6 +172,7 @@ void loop() {
             // DECIMATION 回ごとに1回計測
             if (deci_counter == DECIMATION - 1 ){
                 Serial.print("-");
+                deci_counter = 0;
                 //  電流源の動作確認
                 if ( meas_unit.getStatus() ){
                     //  動作していれば  1回計測、表示
@@ -179,7 +180,6 @@ void loop() {
                     meas_unit.readLevel();
                     lcd_display.showLevel();
                     meas_unit.setVmon(level_meter.getLiquidLevel());
-                    deci_counter = 0;
                 } else {
                     //  動作していなければ計測をターミネート
                     meas_unit.currentOff();
@@ -187,7 +187,8 @@ void loop() {
                     // エラー表示
                     level_meter.setSensorError();
                     lcd_display.showLevel();
-                    meas_unit.setVmon(level_meter.getLiquidLevel());
+                    // meas_unit.setVmon(level_meter.getLiquidLevel());
+                    meas_unit.setVmonFailed();
                     // タイマーモードに移行
                     level_meter.setMode(Timer);
                     Serial.println("  Current Sorce Fail. Cont meas terminated...");
@@ -219,7 +220,11 @@ void loop() {
             level_meter.setMode(Manual);
             wrapper_meas_single();
             lcd_display.showLevel();
-            meas_unit.setVmon(level_meter.getLiquidLevel());
+            if(level_meter.isSensorError()){
+                meas_unit.setVmonFailed();
+            } else {
+                meas_unit.setVmon(level_meter.getLiquidLevel());
+            }
             level_meter.setMode(Timer);
         }
     }
@@ -255,7 +260,11 @@ void loop() {
                 lcd_display.showMode();
                 wrapper_meas_single();
                 lcd_display.showLevel();
-                meas_unit.setVmon(level_meter.getLiquidLevel());
+                if(level_meter.isSensorError()){
+                    meas_unit.setVmonFailed();
+                } else {
+                    meas_unit.setVmon(level_meter.getLiquidLevel());
+                }
                 // 手動計測中にタイマがタイムアップした場合、それを無視する
                 f_timer_timeup = false;
                 //  測定している間のスイッチ操作を無視
@@ -273,6 +282,7 @@ void loop() {
                     //  電流源にエラーがあればエラー表示してタイマーモードへ移行
                     level_meter.setSensorError();
                     lcd_display.showLevel();
+                    meas_unit.setVmonFailed();
                     level_meter.setMode(Timer);
                 } else {
                     level_meter.clearSensorError();

--- a/measurement.h
+++ b/measurement.h
@@ -52,6 +52,7 @@ class Measurement {
     //  モニタ出力制御
     
         void setVmon(uint16_t);
+        void setVmonFailed(void);
 
     private:
         //  電流設定用DAコンバータ

--- a/measurement.ino
+++ b/measurement.ino
@@ -270,10 +270,12 @@ boolean Measurement::measSingle(void){
 
         //  センサへの熱伝導待ち時間の間に3回計測する（動いていますというフィードバックのため）
         for (uint16_t i =0 ; i < 3; i++){
+            f_sensor_error = (pio->digitalRead(PIO_CURRENT_ERRFLAG) == LOW);
             Measurement::readLevel();
             delay(delay_time/3);
         }
         //  確定値の計測
+        f_sensor_error = (pio->digitalRead(PIO_CURRENT_ERRFLAG) == LOW);
         Measurement::readLevel();
         Measurement::currentOff();
 
@@ -416,5 +418,16 @@ void Measurement::setVmon(uint16_t value){
     //     100.0% = 1.1V, 0%=0.1V 
         v_mon_dac->setVoltage(da_value);
     }
+}
+
+/*!
+ * @brief アナログモニタ出力を0Vに設定して、計測不能状態を示す
+ * @param voild
+ */
+void Measurement::setVmonFailed(void){
+
+    v_mon_dac->setVoltage((uint16_t) 0);
 
 }
+
+


### PR DESCRIPTION
LCD上にERRORが表示された場合に、アナログモニタ出力を0Vに設定するようにした。
実機で動作確認済み。